### PR TITLE
Install Vagrant 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
   - ANSIBLE_TAGS=golang
   # Node.js
   - ANSIBLE_TAGS=node
+  # Vagrant
+  - ANSIBLE_TAGS=vagrant
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ set up, more or less from scratch. I have not tested any of these on my OS X sys
 This is forked off from [caarlos0/machine](https://github.com/caarlos0/machine) with my 
 specific requirements and updates.
 
-# Ansible Roles
+## Ansible Roles
 
 [caarlos0](https://github.com/caarlos0) suggested splitting the tasks into roles that 
 could be a good idea, especially for running tests in Travis CI, but for now this works 
@@ -18,3 +18,7 @@ quite nicely as I can keep all the files in one place.
 - [kbrebanov.erlang](https://github.com/kbrebanov/ansible-erlang)
 - [markosamuli.visual-studio-code](https://github.com/markosamuli/ansible-visual-studio-code)
 - [markosamuli.terraform](https://github.com/markosamuli/ansible-terraform)
+
+## Homebrew Taps
+
+- Install Vagrant 1.8 from [markosamuli/vagrant](https://github.com/markosamuli/homebrew-vagrant)

--- a/main.yml
+++ b/main.yml
@@ -49,7 +49,9 @@
 
     # Install Vagrant and Virtualbox early as well
     - include: tasks/vagrant.yml
+      tags: vagrant 
     - include: tasks/virtualbox.yml
+      tags: virtualbox
 
     # Firewall
     - include: tasks/ufw.yml

--- a/tasks/vagrant.yml
+++ b/tasks/vagrant.yml
@@ -1,6 +1,9 @@
+--
+
 - name: Ubuntu | Install Vagrant
   package: 
     name: vagrant
+    state: latest
   when: is_ubuntu
 
 - name: OS X | Setup Vagrant tap

--- a/tasks/vagrant.yml
+++ b/tasks/vagrant.yml
@@ -1,4 +1,16 @@
 - name: Ubuntu | Install Vagrant
-  package: name=vagrant
+  package: 
+    name: vagrant
   when: is_ubuntu
-  tags: vagrant
+
+- name: OS X | Setup Vagrant tap
+  homebrew_tap:
+    name: markosamuli/vagrant
+    state: present
+  when: is_osx
+  
+- name: OS X | Install Vagrant
+  homebrew_cask:
+    name: vagrant18
+    state: present 
+  when: is_osx

--- a/tasks/vagrant.yml
+++ b/tasks/vagrant.yml
@@ -1,9 +1,23 @@
---
+---
+
+- set_fact:
+    vagrant_version: "1.8.7"
+
+- set_fact:
+    vagrant_arch: "x86_64"
+  when: ansible_architecture == "x86_64"
+
+- set_fact:
+    vagrant_arch: "i686"
+  when: ansible_architecture == "i386"
+
+- set_fact:
+    vagrant_deb: "https://releases.hashicorp.com/vagrant/{{ vagrant_version }}/vagrant_{{ vagrant_version }}_{{ vagrant_arch }}.deb"
+  when: is_ubuntu
 
 - name: Ubuntu | Install Vagrant
-  package: 
-    name: vagrant
-    state: latest
+  apt: 
+    deb: "{{ vagrant_deb }}"
   when: is_ubuntu
 
 - name: OS X | Setup Vagrant tap


### PR DESCRIPTION
**OS X** 

Install Vagrant 1.8 from [markosamuli/vagrant|https://github.com/markosamuli/homebrew-vagrant] Homebrew tap on OS X.

**Ubuntu**

Install Vagrant 1.8.7 from [Hashicorp release package|https://releases.hashicorp.com/vagrant/1.8.7/] instead of the default Ubuntu package.